### PR TITLE
Add Low-Level Discovery settings for bacula clients

### DIFF
--- a/bacula-autodiscovery.conf
+++ b/bacula-autodiscovery.conf
@@ -1,0 +1,2 @@
+# Bacula hosts autodiscovery
+UserParameter=bacula.clients,. /etc/bacula/bacula-zabbix.conf; echo {\"data\":[ ; /usr/bin/mysql -NB -h$baculaDbAddr -P$baculaDbPort -u$baculaDbUser -p$baculaDbPass -D$baculaDbName -e 'select CONCAT("{\"{#CLIENT}\":\"",Name,"\"},") from Client;' | sed '$ s/.$//' ; echo ]}


### PR DESCRIPTION
Hello.
With this file being put into `/etc/zabbix/conf.d`, one will be able to create hosts for all clients automatically. If you'd like that, ping me, I'll add hosts autodiscovery into template and will adjust Readme.
Note: for adjusting template first we need to separate client and server templates in #3.
