### PR TITLE
Update bash script with fixes for PostgreSQL and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is mainly composed by a bash script and a Zabbix template. The bash script reads values from Bacula Catalog and sends it to Zabbix Server. While the Zabbix template has items and other configurations that receive this values, start alerts and generate graphs and screens. This material was created using Bacula at 7.0.5 version and Zabbix at 2.4.5 version in a GNU/Linux CentOS 7 operational system.
 
+Tested with Bacula 9.4.x with PostgreSQL 11 backend and Zabbix 4.0.x on GNU/Linux Debian 9
+
 ### Abilities
 
 - Customizable and easy to set up
@@ -30,7 +32,7 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 - **Items**
 
   This Zabbix template has two types of items, the items to receive data of backup jobs, and the itens to receive data of Bacula's processes. The items that receive data of Bacula's processes are described below:
-  
+
   - *Bacula Director is running*: Get the Bacula Director process status. The process name is defined by the variable {$BACULA.DIR}, and has its default value as 'bacula-dir'. This item needs to be disabled in hosts that are Bacula's clients only.
   - *Bacula Storage is running*: Get the Bacula Storage process status. The process name is defined by the variable {$BACULA.SD}, and has its default value as 'bacula-sd'. This item needs to be disabled in hosts that are Bacula's clients only.
   - *Bacula File is running*: Get the Bacula File process status. The process name is defined by the variable {$BACULA.FD}, and has its default value as 'bacula-fd'.
@@ -103,6 +105,22 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
   }
   ```
 
+Note that if there is already a mailcommand set then an additional wrapper script has to be used.
+For example if the original mailcommand was:
+  ```
+  mailcommand = "/usr/sbin/bsmtp -h localhost -f \"\(Bacula\) \<bacula@backup-bacula.tokyo.tequila.jp\>\" -s \"Bacula: %t %e of %c (%n) %l\" %r"
+  ```
+then it is necessary to use and external script like the bacula-sender.sh script provided. Put the file into /var/spool/bacula/ and set the permissions as below:
+  ```
+  chown bacula:bacula /var/spool/bacula/bacula-sender.bash
+  chmod 700 /var/spool/bacula/bacula-sender.bash
+  ```
+The file is setup to work with the example mail command from above. Change the Messages mailcommand to
+  ```
+  mailcommand = "/var/spool/bacula/bacula-sender.sh \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
+  ```
+and leave everthing else the same.
+
 4. Now restart the Bacula Director service. In my case I used this command:
   ```
   systemctl restart bacula-dir
@@ -117,7 +135,9 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 - **Bacula**:
 
   - http://www.bacula.org/7.0.x-manuals/en/main
+  - https://www.bacula.org/9.4.x-manuals/en/main/
   - http://www.bacula.com.br/manual/Messages_Resource.html
+  - https://www.bacula.org/9.4.x-manuals/en/main/Messages_Resource.html
   - http://www.bacula-web.org/docs.html
   - http://resources.infosecinstitute.com/data-backups-bacula-notifications
 

--- a/bacula-sender.bash
+++ b/bacula-sender.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# wrapper for sending mail and running zabbix sender script
+
+# just parse for each command line option
+job_type="${1}"; # %t
+job_exit_status="${2}"; # %e
+client_name="${3}"; # %c
+job_name="${4}"; # %n
+job_level="${5}"; # %l
+recipients="${6}"; # %r
+job_id="${7}"; # %i
+
+/usr/sbin/bsmtp -h localhost -f "(Bacula) <bacula@backup-bacula.tokyo.tequila.jp>" -s "Bacula: ${job_type} ${job_exit_status} of ${client_name} (${job_name}) ${job_level}" ${recipients};
+/var/spool/bacula/bacula-zabbix.bash ${job_id};
+
+exit;

--- a/bacula-zabbix.bash
+++ b/bacula-zabbix.bash
@@ -2,9 +2,12 @@
 
 # Import configuration file
 source /etc/bacula/bacula-zabbix.conf
+# start tee logging
+LOG="tee -a ${scriptLogFile}"
 
 # Get Job ID from parameter
 baculaJobId="$1"
+echo "[$baculaJobId] START@ $(date +"%F %T")" | ${LOG} > /dev/null
 if [ -z $baculaJobId ] ; then exit 3 ; fi
 
 # Test if zabbix_sender exists and execute permission is granted, if not, exit
@@ -12,13 +15,29 @@ if [ ! -x $zabbixSender ] ; then exit 5 ; fi
 
 # Chose which database command to use
 case $baculaDbSgdb in
-  P) sql="PGPASSWORD=$baculaDbPass /usr/bin/psql -h$baculaDbAddr -p$baculaDbPort -U$baculaDbUser -d$baculaDbName -c" ;;
-  M) sql="/usr/bin/mysql -NB -h$baculaDbAddr -P$baculaDbPort -u$baculaDbUser -p$baculaDbPass -D$baculaDbName -e" ;;
+  P)
+    # alternative if used with traditional -h/-p/-U/-d parameters
+    #export PGPASSWORD=$baculaDbPass;
+    # use -X to ignore any .psqlrc and only return data no headers (-t) in blank output format (-A)
+    # also use --dbname to get full command with password in one line
+    sql="/usr/bin/psql -A -t -X --dbname=postgresql://$baculaDbUser:$baculaDbPass@$baculaDbAddr:$baculaDbPort/$baculaDbName -c"
+    timestampdiff="EXTRACT(EPOCH FROM endtime - starttime)"
+    speed="ROUND((JobBytes / ${timestampdiff} / 1024)::NUMERIC, 2)"
+    compression="ROUND(1 - JobBytes::NUMERIC / ReadBytes::NUMERIC, 2)"
+  ;;
+  M)
+    sql="/usr/bin/mysql -NB -h$baculaDbAddr -P$baculaDbPort -u$baculaDbUser -p$baculaDbPass -D$baculaDbName -e"
+    timestampdiff="timestampdiff(second, StartTime, EndTime)"
+    speed="round(JobBytes / ${timestampdiff} / 1024, 2)"
+    compression="round(1 - JobBytes / ReadBytes, 2)"
+  ;;
   *) exit 7 ;;
 esac
+echo "[$baculaJobId] SQL Type: $baculaDbSgdb" | ${LOG} > /dev/null
 
 # Get Job type from database, then if it is a backup job, proceed, if not, exit
 baculaJobType=$($sql "select Type from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Type: ${baculaJobType}" | ${LOG} > /dev/null
 if [ "$baculaJobType" != "B" ] ; then exit 9 ; fi
 
 # Get Job level from database and classify it as Full, Differential, or Incremental
@@ -29,6 +48,7 @@ case $baculaJobLevel in
   'I') level='incr' ;;
   *)   exit 11 ;;
 esac
+echo "[$baculaJobId] Job Level: ${baculaJobLevel} => ${level}" | ${LOG} > /dev/null
 
 # Get Job exit status from database and classify it as OK, OK with warnings, or Fail
 baculaJobStatus=$($sql "select JobStatus from Job where JobId=$baculaJobId;" 2>/dev/null)
@@ -38,42 +58,51 @@ case $baculaJobStatus in
   "W") status=1 ;;
   *)   status=2 ;;
 esac
+echo "[$baculaJobId] Job Status: ${baculaJobStatus} => ${status}" | ${LOG} > /dev/null
 
 # Get client's name from database
 baculaClientName=$($sql "select Client.Name from Client,Job where Job.ClientId=Client.ClientId and Job.JobId=$baculaJobId;" 2>/dev/null)
 if [ -z $baculaClientName ] ; then exit 15 ; fi
+echo "[$baculaJobId] Client Name: ${baculaClientName}" | ${LOG} > /dev/null
 
 # Initialize return as zero
 return=0
 
 # Send Job exit status to Zabbix server
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+1)) ; fi
 
 # Get from database the number of bytes transferred by the Job and send it to Zabbix server
 baculaJobBytes=$($sql "select JobBytes from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
+echo "[$baculaJobId] Job Bytes: ${baculaJobBytes}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+2)) ; fi
 
 # Get from database the number of files transferred by the Job and send it to Zabbix server
 baculaJobFiles=$($sql "select JobFiles from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
+echo "[$baculaJobId] Job Files: ${baculaJobFiles}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+4)) ; fi
 
 # Get from database the time spent by the Job and send it to Zabbix server
-baculaJobTime=$($sql "select timestampdiff(second,StartTime,EndTime) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
+baculaJobTime=$($sql "select ${timestampdiff} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Time: ${baculaJobTime}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+8)) ; fi
 
 # Get Job speed from database and send it to Zabbix server
-baculaJobSpeed=$($sql "select round(JobBytes/timestampdiff(second,StartTime,EndTime)/1024,2) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
+baculaJobSpeed=$($sql "select ${speed} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Speed: ${baculaJobSpeed}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+16)) ; fi
 
 # Get Job compression rate from database and send it to Zabbix server
-baculaJobCompr=$($sql "select round(1-JobBytes/ReadBytes,2) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
+baculaJobCompr=$($sql "select ${compression} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Compression: ${baculaJobCompr}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+32)) ; fi
+
+echo "[$baculaJobId] END@ $(date +"%F %T") RETURN: ${return}" | ${LOG} > /dev/null
 
 # Exit with return status
 exit $return

--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -7,7 +7,7 @@ baculaDbSgdb='M'
 # IP address or FQDN of database server
 baculaDbAddr='127.0.0.1'
 
-# TCP port of database server
+# TCP port of database server (3306 of MySQL, 5432 for PostgreSQL)
 baculaDbPort='3306'
 
 # Name of the database used by Bacula
@@ -22,11 +22,14 @@ baculaDbPass='linux01'
 
 ### ZABBIX CONFIG ###
 
-# IP address or FQDN of Zabbix server
-zabbixSrvAddr='192.168.37.200'
+# Config for the zabbix agent
+zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
-# TCP port of Zabbix server
-zabbixSrvPort='10051'
+# Config for the zabbix agent
+zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
-# Path to zabbix_sender command
-zabbixSender='/usr/bin/zabbix_sender'
+
+### SCRIPT LOG FILE ###
+
+# debug log file (must be writeable by bacula user)
+scriptLogFile="/var/log/bacula/bacula-zabbix.log";


### PR DESCRIPTION
The script has fixes to work with PostgreSQL correctly (round, timestamp calculations) and also added logging.

An additional bacula-sender.bash script is added to work as a wrapper for sending mail and zabbix connection at the same time.

Update README file with info about this