### PR TITLE
Some features from other PRs 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
     "mailcommand",
     "Prefered",
     "tokyo",
-    "whitoud"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "cSpell.words": [
+    "Baculum",
+    "bsmtp",
+    "mailcommand",
+    "Prefered",
+    "tokyo",
+    "whitoud"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is mainly composed by a bash script and a Zabbix template. The bash script reads values from Bacula Catalog and sends it to Zabbix Server. While the Zabbix template has items and other configurations that receive this values, start alerts and generate graphs and screens. This material was created using Bacula at 7.0.5 version and Zabbix at 2.4.5 version in a GNU/Linux CentOS 7 operational system.
 
+Tested with Bacula 9.4.x with PostgreSQL 11 backend and Zabbix 4.0.x on GNU/Linux Debian 9
+
 ### Abilities
 
 - Customizable and easy to set up
@@ -30,7 +32,7 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 - **Items**
 
   This Zabbix template has two types of items, the items to receive data of backup jobs, and the itens to receive data of Bacula's processes. The items that receive data of Bacula's processes are described below:
-  
+
   - *Bacula Director is running*: Get the Bacula Director process status. The process name is defined by the variable {$BACULA.DIR}, and has its default value as 'bacula-dir'. This item needs to be disabled in hosts that are Bacula's clients only.
   - *Bacula Storage is running*: Get the Bacula Storage process status. The process name is defined by the variable {$BACULA.SD}, and has its default value as 'bacula-sd'. This item needs to be disabled in hosts that are Bacula's clients only.
   - *Bacula File is running*: Get the Bacula File process status. The process name is defined by the variable {$BACULA.FD}, and has its default value as 'bacula-fd'.
@@ -103,6 +105,22 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
   }
   ```
 
+Note that if there is already a mailcommand set then an additional wrapper script has to be used.
+For example if the original mailcommand was:
+  ```
+  mailcommand = "/usr/sbin/bsmtp -h localhost -f \"\(Bacula\) \<bacula@backup-bacula.tokyo.tequila.jp\>\" -s \"Bacula: %t %e of %c (%n) %l\" %r"
+  ```
+then it is necessary to use and external script like the bacula-sender.sh script provided. Put the file into /var/spool/bacula/ and set the permissions as below:
+  ```
+  chown bacula:bacula /var/spool/bacula/bacula-sender.bash
+  chmod 700 /var/spool/bacula/bacula-sender.bash
+  ```
+The file is setup to work with the example mail command from above. Change the Messages mailcommand to
+  ```
+  mailcommand = "/var/spool/bacula/bacula-sender.sh \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
+  ```
+and leave everthing else the same.
+
 4. Now restart the Bacula Director service. In my case I used this command:
   ```
   systemctl restart bacula-dir
@@ -117,7 +135,9 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 - **Bacula**:
 
   - http://www.bacula.org/7.0.x-manuals/en/main
+  - https://www.bacula.org/9.4.x-manuals/en/main/
   - http://www.bacula.com.br/manual/Messages_Resource.html
+  - https://www.bacula.org/9.4.x-manuals/en/main/Messages_Resource.html
   - http://www.bacula-web.org/docs.html
   - http://resources.infosecinstitute.com/data-backups-bacula-notifications
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project is mainly composed by a bash script and a Zabbix template. The bash
 
 Tested with Bacula 9.4.x with PostgreSQL 11 backend and Zabbix 4.0.x on GNU/Linux Debian 9
 
+Tested with Bacula 13.0.x with PostgreSQL 14 backend and Zabbix 6.4.x on GNU/Linux Ubuntu 22.04
+
 ### Abilities
 
 - Customizable and easy to set up
@@ -82,6 +84,8 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 - Knowledge about GNU/Linux operational systems
 
 ### Installation
+
+*Note*: If your Bacula uses a config path other than `/etc/bacula` (e.g., Bacula.org builds use `/opt/bacula/etc`), you should set the valid path to `bacula-zabbix.conf` in `bacula-zabbix.bash`.
 
 1. Create the configuration file `/etc/bacula/bacula-zabbix.conf` as the sample in this repository, customize it for your infrastructure environment, and set the permissions as below:
   ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ chmod +x /var/spool/bacula/bacula-running-zabbix-sender.bash
 The bellow example is running every 10 minutes
 ```
 */10 * * * * /var/spool/bacula/bacula-label-zabbix-sender.bash
-*/10 * * * */var/spool/bacula/bacula-running-zabbix-sender.bash
+*/10 * * * * /var/spool/bacula/bacula-running-zabbix-sender.bash
 ```
 
 # Troubleshooting Commands:

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ For example if the original mailcommand was:
   ```
   mailcommand = "/usr/sbin/bsmtp -h localhost -f \"\(Bacula\) \<bacula@backup-bacula.tokyo.tequila.jp\>\" -s \"Bacula: %t %e of %c (%n) %l\" %r"
   ```
-then it is necessary to use and external script like the bacula-sender.sh script provided. Put the file into /var/spool/bacula/ and set the permissions as below:
+then it is necessary to use and external script like the bacula-sender.bash script provided. Put the file into /var/spool/bacula/ and set the permissions as below:
   ```
   chown bacula:bacula /var/spool/bacula/bacula-sender.bash
   chmod 700 /var/spool/bacula/bacula-sender.bash
   ```
 The file is setup to work with the example mail command from above. Change the Messages mailcommand to
   ```
-  mailcommand = "/var/spool/bacula/bacula-sender.sh \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
+  mailcommand = "/var/spool/bacula/bacula-sender.bash \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
   ```
 and leave everthing else the same.
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
 
 ### Installation
 
-*Note*: If your Bacula uses a config path other than `/etc/bacula` (e.g., Bacula.org builds use `/opt/bacula/etc`), you should set the valid path to `bacula-zabbix.conf` in `bacula-zabbix.bash`.
+*Note*: If your Bacula uses a config path other than `/opt/bacula/etc` (e.g., Bacula.org builds use `/etc/bacula`), you should set the valid path to `bacula-zabbix.conf` in `bacula-zabbix.bash`.
 
-1. Create the configuration file `/etc/bacula/bacula-zabbix.conf` as the sample in this repository, customize it for your infrastructure environment, and set the permissions as below:
+1. Create the configuration file `/opt/bacula/etc/bacula-zabbix.conf` as the sample in this repository, customize it for your infrastructure environment, and set the permissions as below:
   ```
-  chown root:bacula /etc/bacula/bacula-zabbix.conf
-  chmod 640 /etc/bacula/bacula-zabbix.conf
+  chown root:bacula /opt/bacula/etc/bacula-zabbix.conf
+  chmod 640 /opt/bacula/etc/bacula-zabbix.conf
   ```
 
 2. Create the bash script file `/var/spool/bacula/bacula-zabbix.bash` by copying it from this repository and set the permissions as below:
@@ -99,7 +99,7 @@ Link this Zabbix template to each host that has a Bacula's backup job implemente
   chmod 700 /var/spool/bacula/bacula-zabbix.bash
   ```
 
-3. Edit the Bacula Director configuration file `/etc/bacula/bacula-dir.conf` to start the script at the finish of each job. To do this you need to change the lines described below in the Messages resource that is used by all the configured jobs:
+3. Edit the Bacula Director configuration file `/opt/bacula/etc/bacula-dir.conf` to start the script at the finish of each job. To do this you need to change the lines described below in the Messages resource that is used by all the configured jobs:
   ```
   Messages {
     ...
@@ -121,9 +121,17 @@ then it is necessary to use and external script like the bacula-sender.bash scri
   ```
 The file is setup to work with the example mail command from above. Change the Messages mailcommand to
   ```
+  # Via arquivo bacula-dir.conf
   mailcommand = "/var/spool/bacula/bacula-sender.bash \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
   ```
-and leave everthing else the same.
+
+Note that if you edit the message via Baculum WEB(Prefered and no restart needed) you should use whitoud "\":
+  ```
+  # Via WEB:
+  mailcommand = "/var/spool/bacula/bacula-sender.bash "%t" "%e" "%c" "%n" "%l" "%r" "%i""
+  ```
+
+and leave everything else the same.
 
 4. Now restart the Bacula Director service. In my case I used this command:
   ```
@@ -133,6 +141,12 @@ and leave everthing else the same.
 5. Make a copy of the Zabbix template from this repository and import it to your Zabbix server.
 
 6. Edit your hosts that have configured backup jobs to use this template. Don't forget to edit the variables with the Bacula's processes names, and to disable in hosts that are only Bacula's clients the items that check the Bacula Director and Storage processes.
+
+# Troubleshooting Commands:
+- `tail -f /var/log/syslog`
+- `tail -f /var/log/bacula/bacula-zabbix.log`
+- `docker logs -f zabbix-snmptraps-1 -n 100`
+- `/var/log/zabbix/zabbix_server.log`
 
 ### References
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ and leave everything else the same.
 
 6. Edit your hosts that have configured backup jobs to use this template. Don't forget to edit the variables with the Bacula's processes names, and to disable in hosts that are only Bacula's clients the items that check the Bacula Director and Storage processes.
 
+### New Features:
+- alert when there is action need for labeling media
+- monitor running jobs
+- alert monitor jobs when they shouldn't be running
+
+7. Put the files into /var/spool/bacula/ and set the permissions as below:
+```
+chmod +x /var/spool/bacula/bacula-label-zabbix-sender.bash
+chmod +x /var/spool/bacula/bacula-running-zabbix-sender.bash
+```
+
+8. Create a cron to run and send the data to Zabbix:
+The bellow example is running every 10 minutes
+```
+*/10 * * * * /var/spool/bacula/bacula-label-zabbix-sender.bash
+*/10 * * * */var/spool/bacula/bacula-running-zabbix-sender.bash
+```
+
 # Troubleshooting Commands:
 - `tail -f /var/log/syslog`
 - `tail -f /var/log/bacula/bacula-zabbix.log`

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The file is setup to work with the example mail command from above. Change the M
   mailcommand = "/var/spool/bacula/bacula-sender.bash \"%t\" \"%e\" \"%c\" \"%n\" \"%l\" \"%r\" \"%i\""
   ```
 
-Note that if you edit the message via Baculum WEB(Prefered and no restart needed) you should use whitoud "\":
+Note that if you edit the message via Baculum WEB(Prefered and no restart needed) you should use without "\":
   ```
   # Via WEB:
   mailcommand = "/var/spool/bacula/bacula-sender.bash "%t" "%e" "%c" "%n" "%l" "%r" "%i""

--- a/bacula-label-zabbix-sender.bash
+++ b/bacula-label-zabbix-sender.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Import configuration file
+source /opt/bacula/etc/bacula-zabbix.conf
+
+# Bacula hostname on Zabbix
+baculaHost="bacula-fd"
+
+# Executa o comando 'status dir' via bconsole e captura a saída
+output=$(echo "status dir" | bconsole)
+
+# Conta o número de jobs que estão aguardando por mídia (label)
+label_jobs=$(echo "$output" | grep -c "waiting for media")
+
+# Envia o valor para o Zabbix via zabbix_sender
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -s "$baculaHost" -k "bacula.label.jobs" -o "$label_jobs"

--- a/bacula-running-zabbix-sender.bash
+++ b/bacula-running-zabbix-sender.bash
@@ -13,7 +13,7 @@ output=$(echo "status dir" | bconsole)
 running_jobs=$(echo "$output" | grep -c "is running")
 
 # Captura o horário atual (hora em formato de 24h)
-current_hour=$(date +"%H")
+current_hour=$(date +"%-H")
 
 # Sempre envia o número de jobs rodando para o Zabbix
 $zabbixSender -z $zabbixServer -c $zabbixAgentConfig -s "$baculaHost" -k "bacula.running.jobs" -o "$running_jobs"

--- a/bacula-running-zabbix-sender.bash
+++ b/bacula-running-zabbix-sender.bash
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Importa o arquivo de configuração
+source /opt/bacula/etc/bacula-zabbix.conf
+
+# Nome do host do Bacula no Zabbix
+baculaHost="bacula-fd"
+
+# Executa o comando 'status dir' via bconsole e captura a saída
+output=$(echo "status dir" | bconsole)
+
+# Conta o número de jobs que estão rodando (status Running)
+running_jobs=$(echo "$output" | grep -c "is running")
+
+# Captura o horário atual (hora em formato de 24h)
+current_hour=$(date +"%H")
+
+# Sempre envia o número de jobs rodando para o Zabbix
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -s "$baculaHost" -k "bacula.running.jobs" -o "$running_jobs"
+
+# Verifica se o horário está entre 9h e 13h (inclusive) e se há mais de 1 job rodando
+if [[ $current_hour -ge 9 && $current_hour -le 11 && $running_jobs -ge 1 ]]; then
+    # Envia o alerta para o Zabbix
+    $zabbixSender -z $zabbixServer -c $zabbixAgentConfig -s "$baculaHost" -k "bacula.running.jobs.alert" -o "$running_jobs"
+fi

--- a/bacula-sender.bash
+++ b/bacula-sender.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# wrapper for sending mail and running zabbix sender script
+
+# just parse for each command line option
+job_type="${1}"; # %t
+job_exit_status="${2}"; # %e
+client_name="${3}"; # %c
+job_name="${4}"; # %n
+job_level="${5}"; # %l
+recipients="${6}"; # %r
+job_id="${7}"; # %i
+
+/usr/sbin/bsmtp -h localhost -f "(Bacula) <bacula@backup-bacula.tokyo.tequila.jp>" -s "Bacula: ${job_type} ${job_exit_status} of ${client_name} (${job_name}) ${job_level}" ${recipients};
+/var/spool/bacula/bacula-zabbix.bash ${job_id};
+
+exit;

--- a/bacula-sender.bash
+++ b/bacula-sender.bash
@@ -3,15 +3,25 @@
 # wrapper for sending mail and running zabbix sender script
 
 # just parse for each command line option
-job_type="${1}"; # %t
-job_exit_status="${2}"; # %e
-client_name="${3}"; # %c
-job_name="${4}"; # %n
-job_level="${5}"; # %l
-recipients="${6}"; # %r
-job_id="${7}"; # %i
+job_type="$1";        # %t
+job_exit_status="$2"; # %e
+client_name="$3";     # %c
+job_name="$4";        # %n
+job_level="$5";       # %l
+recipients="$6";      # %r
+job_id="$7";          # %i
 
-/usr/sbin/bsmtp -h localhost -f "(Bacula) <bacula@backup-bacula.tokyo.tequila.jp>" -s "Bacula: ${job_type} ${job_exit_status} of ${client_name} (${job_name}) ${job_level}" ${recipients};
-/var/spool/bacula/bacula-zabbix.bash ${job_id};
+# for bsmpt
+# /usr/sbin/bsmtp -h localhost \
+#                -f "(Bacula) <bacula@backup-bacula.tokyo.tequila.jp>" \
+#                -s "Bacula: ${job_type} ${job_exit_status} of \
+#                ${client_name} (${job_name}) ${job_level}" ${recipients};
+
+# for postfix
+/usr/bin/mail -r "mail@example.com.br" \
+              -s "Bacula Sistema de Backup: ${job_type} ${job_exit_status} of \
+               ${client_name} (${job_name}) ${job_level}" \
+               "${recipients}"
+/var/spool/bacula/bacula-zabbix.bash $job_id;
 
 exit;

--- a/bacula-template.yaml
+++ b/bacula-template.yaml
@@ -1,0 +1,684 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: 1100382624544b09b40ea63f5c24f157
+      template: 'Template Bacula'
+      name: 'Template Bacula'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 3ad7999918ff4da7b2f302015c713ccc
+          name: 'Backup Differential Bytes'
+          type: TRAP
+          key: bacula.diff.job.bytes
+          units: B
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 6ff9c19a60f34ec7aa1074dc3ac6ac4f
+          name: 'Backup Differential Compression'
+          type: TRAP
+          key: bacula.diff.job.compr
+          value_type: FLOAT
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 9c65de66f0a447caa149447c436c5527
+          name: 'Backup Differential Files'
+          type: TRAP
+          key: bacula.diff.job.files
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: fefdc2f4ef1a40d1864f3d7b3d67c4cf
+          name: 'Backup Differential Speed'
+          type: TRAP
+          key: bacula.diff.job.speed
+          value_type: FLOAT
+          units: KB/s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: f7d38d4e07714fe69cf13b8819b2d09c
+          name: 'Backup Differential OK'
+          type: TRAP
+          key: bacula.diff.job.status
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 80b4fcf5deaa464188495f57c53fcb2d
+              expression: 'last(/Template Bacula/bacula.diff.job.status)>1'
+              name: 'Backup Differential FAIL in {HOST.NAME}'
+              priority: AVERAGE
+        - uuid: 8e797c898f0a4fdc8d0b661a742d8f8b
+          name: 'Backup Differential Time'
+          type: TRAP
+          key: bacula.diff.job.time
+          units: s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 4de1bc4dbc274085a9731a4be4027b0e
+          name: 'Backup Full Bytes'
+          type: TRAP
+          key: bacula.full.job.bytes
+          units: B
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 439cc473445e48658239ea84ee4f9a57
+          name: 'Backup Full Compression'
+          type: TRAP
+          key: bacula.full.job.compr
+          value_type: FLOAT
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: e09d956cf8ab4c259d50e780b17f7d25
+          name: 'Backup Full Files'
+          type: TRAP
+          key: bacula.full.job.files
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 46670c1c9bc242e5a629d26d89e84450
+          name: 'Backup Full Speed'
+          type: TRAP
+          key: bacula.full.job.speed
+          value_type: FLOAT
+          units: KB/s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 06e81a5e97264494986ce9c6f5fe135d
+          name: 'Backup Full OK'
+          type: TRAP
+          key: bacula.full.job.status
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 1b6c1bcf5a684bef99d50fb1582abe27
+              expression: 'last(/Template Bacula/bacula.full.job.status)>1'
+              name: 'Backup Full FAIL in {HOST.NAME}'
+              priority: HIGH
+        - uuid: 96b4480f70e448eca6d48f44baf6f716
+          name: 'Backup Full Time'
+          type: TRAP
+          key: bacula.full.job.time
+          units: s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: d3f71da5d0a14239ad8a5393ca1fb777
+          name: 'Backup Incremental Bytes'
+          type: TRAP
+          key: bacula.incr.job.bytes
+          units: B
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 40193f25d5a64f2db3a8bf2bba9ac66c
+          name: 'Backup Incremental Compression'
+          type: TRAP
+          key: bacula.incr.job.compr
+          value_type: FLOAT
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 5b002a76d411479fb8a937580024c1e2
+          name: 'Backup Incremental Files'
+          type: TRAP
+          key: bacula.incr.job.files
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 0bdcc2a716de47d0a7632269dd2df5e8
+          name: 'Backup Incremental Speed'
+          type: TRAP
+          key: bacula.incr.job.speed
+          value_type: FLOAT
+          units: KB/s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 8c0f3bd9e5e64ee68c47e26acbd2f895
+          name: 'Backup Incremental OK'
+          type: TRAP
+          key: bacula.incr.job.status
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 68663c9163d14d718f53f3905b1542a3
+              expression: 'last(/Template Bacula/bacula.incr.job.status)>1'
+              name: 'Backup Incremental FAIL in {HOST.NAME}'
+              priority: WARNING
+        - uuid: ef04614a446b4049bad4c8384b2a6317
+          name: 'Backup Incremental Time'
+          type: TRAP
+          key: bacula.incr.job.time
+          units: s
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 4be6a77f74cb409d96299dbcab97ec1f
+          name: 'Backup Server Label Jobs'
+          type: TRAP
+          key: bacula.label.jobs
+          description: 'Verifica se algum job pracisa de disco, use o comando label se necessário'
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 3f094c8fcb2541229812b7bf70756a11
+              expression: 'last(/Template Bacula/bacula.label.jobs)>=1'
+              name: 'Bacula Server Label Action Needed'
+              priority: DISASTER
+              description: 'Precisa Rotular ou dar Prune num volume para ser usado para o Job'
+        - uuid: d8eb3f69312741a2a3e90a88ed95373c
+          name: 'Backup Server Running Jobs'
+          type: TRAP
+          key: bacula.running.jobs
+          description: 'Conta quantos jobs rodando'
+          tags:
+            - tag: Application
+              value: Bacula
+        - uuid: 3f6fee66ea684ecc81da7dd424e1825f
+          name: 'Backup Server Running Jobs Alerta'
+          type: TRAP
+          key: bacula.running.jobs.alert
+          description: 'Conta quantos jobs rodando'
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 1877420bbfa64029bd081c4e6305254b
+              expression: 'last(/Template Bacula/bacula.running.jobs.alert)>=1'
+              name: 'Bacula Server Running Jobs, Check Bacula for Problem'
+              priority: DISASTER
+              description: 'Não deve haver jobs rodando neste horário.'
+        - uuid: 0c56274d6a294bfb9adbff14ac32c004
+          name: 'Bacula Director is running'
+          key: 'proc.num[{$BACULA.DIR}]'
+          delay: '30'
+          status: DISABLED
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 137371d4594e44e28c424f1f82a23f0c
+              expression: 'last(/Template Bacula/proc.num[{$BACULA.DIR}])=0'
+              name: 'Bacula Director is DOWN in {HOST.NAME}'
+              priority: DISASTER
+        - uuid: a2ec0ddbe8064c448a4a4c9f71bd4c7b
+          name: 'Bacula File is running'
+          key: 'proc.num[{$BACULA.FD}]'
+          delay: '30'
+          status: DISABLED
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: 387918d7c24742fea5e52b3c10204f09
+              expression: 'last(/Template Bacula/proc.num[{$BACULA.FD}])=0'
+              name: 'Bacula File is DOWN in {HOST.NAME}'
+              priority: HIGH
+        - uuid: 2dea8336b4c34da6ae7202765aaa46db
+          name: 'Bacula Storage is running'
+          key: 'proc.num[{$BACULA.SD}]'
+          delay: '30'
+          status: DISABLED
+          tags:
+            - tag: Application
+              value: Bacula
+          triggers:
+            - uuid: eac4c3ade84b472e885b8f1e91e9b27e
+              expression: 'last(/Template Bacula/proc.num[{$BACULA.SD}])=0'
+              name: 'Bacula Storage is DOWN in {HOST.NAME}'
+              priority: DISASTER
+      macros:
+        - macro: '{$BACULA.DIR}'
+          value: bacula-dir
+        - macro: '{$BACULA.FD}'
+          value: bacula-fd
+        - macro: '{$BACULA.SD}'
+          value: bacula-sd
+      dashboards:
+        - uuid: 2caf89765d1a45d29d6b154aeb6b675b
+          name: 'Backup Differential'
+          pages:
+            - widgets:
+                - type: graph
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Differential - Bytes transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Differential - Elapsed time'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '10'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Differential - Compression rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Differential - Files transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Differential - Transfer rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+        - uuid: 79d15cad42874ef79d7feb76811aedc7
+          name: 'Backup Full'
+          pages:
+            - widgets:
+                - type: graph
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Full - Bytes transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Full - Elapsed time'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '10'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Full - Compression rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Full - Files transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Full - Transfer rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+        - uuid: 055bb8ccd72842dc9f3ca8cecc4a82d8
+          name: 'Backup Incremental'
+          pages:
+            - widgets:
+                - type: graph
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Incremental - Bytes transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Incremental - Elapsed time'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  'y': '10'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Incremental - Compression rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Incremental - Files transferred'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+                - type: graph
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'Template Bacula'
+                        name: 'Backup Incremental - Transfer rate'
+                    - type: INTEGER
+                      name: source_type
+                      value: '0'
+  graphs:
+    - uuid: 7ee4319d44884fd0a3453483112ba612
+      name: 'Backup Differential - Bytes transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 9999FF
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.bytes
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.status
+    - uuid: bbadd2c23cd74d31847316842e89a991
+      name: 'Backup Differential - Compression rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: FF9999
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.compr
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.status
+    - uuid: 55cd17b7e2984a3eb8a0c983d7952e38
+      name: 'Backup Differential - Elapsed time'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00EEEE
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.time
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.status
+    - uuid: a62b71155883443bb732360535d6efd4
+      name: 'Backup Differential - Files transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00C800
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.files
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.status
+    - uuid: b9770c5f16b445c2921edff3e100c2b4
+      name: 'Backup Differential - Transfer rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: CCCC00
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.speed
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.diff.job.status
+    - uuid: 12ade03af16940fb9a570f4e3875bddf
+      name: 'Backup Full - Bytes transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 9999FF
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.bytes
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.status
+    - uuid: cafccb411b934f8a8608e39fcb901690
+      name: 'Backup Full - Compression rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: FF9999
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.compr
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.status
+    - uuid: 28c4dea5507e4e23968e4dfd16220dac
+      name: 'Backup Full - Elapsed time'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00EEEE
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.time
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.status
+    - uuid: b8985ea7b2e142a18030f74b5dc443bd
+      name: 'Backup Full - Files transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00C800
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.files
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.status
+    - uuid: fad65525f1b74057b699391b9abc6e21
+      name: 'Backup Full - Transfer rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: CCCC00
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.speed
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.full.job.status
+    - uuid: c67f7184e7fa4488848ba1f9be8fb659
+      name: 'Backup Incremental - Bytes transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 9999FF
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.bytes
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.status
+    - uuid: 1eefdf715da840cc8feb479b8efd3464
+      name: 'Backup Incremental - Compression rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: FF9999
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.compr
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.status
+    - uuid: dd22cfe411af43fea7d5cd7e8164a801
+      name: 'Backup Incremental - Elapsed time'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00EEEE
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.time
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.status
+    - uuid: c7690e1f18cf472997fa87b62b1c1c85
+      name: 'Backup Incremental - Files transferred'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 00C800
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.files
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.status
+    - uuid: 2c3c5a9c60734c9d841853eef2425ad2
+      name: 'Backup Incremental - Transfer rate'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: CCCC00
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.speed
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: C80000
+          item:
+            host: 'Template Bacula'
+            key: bacula.incr.job.status

--- a/bacula-zabbix.bash
+++ b/bacula-zabbix.bash
@@ -2,9 +2,12 @@
 
 # Import configuration file
 source /etc/bacula/bacula-zabbix.conf
+# start tee logging
+LOG="tee -a ${scriptLogFile}"
 
 # Get Job ID from parameter
 baculaJobId="$1"
+echo "[$baculaJobId] START@ $(date +"%F %T")" | ${LOG} > /dev/null
 if [ -z $baculaJobId ] ; then exit 3 ; fi
 
 # Test if zabbix_sender exists and execute permission is granted, if not, exit
@@ -12,13 +15,29 @@ if [ ! -x $zabbixSender ] ; then exit 5 ; fi
 
 # Chose which database command to use
 case $baculaDbSgdb in
-  P) sql="PGPASSWORD=$baculaDbPass /usr/bin/psql -h$baculaDbAddr -p$baculaDbPort -U$baculaDbUser -d$baculaDbName -c" ;;
-  M) sql="/usr/bin/mysql -NB -h$baculaDbAddr -P$baculaDbPort -u$baculaDbUser -p$baculaDbPass -D$baculaDbName -e" ;;
+  P)
+    # alternative if used with traditional -h/-p/-U/-d parameters
+    #export PGPASSWORD=$baculaDbPass;
+    # use -X to ignore any .psqlrc and only return data no headers (-t) in blank output format (-A)
+    # also use --dbname to get full command with password in one line
+    sql="/usr/bin/psql -A -t -X --dbname=postgresql://$baculaDbUser:$baculaDbPass@$baculaDbAddr:$baculaDbPort/$baculaDbName -c"
+    timestampdiff="EXTRACT(EPOCH FROM endtime - starttime)"
+    speed="ROUND((JobBytes / ${timestampdiff} / 1024)::NUMERIC, 2)"
+    compression="ROUND(1 - JobBytes::NUMERIC / ReadBytes::NUMERIC, 2)"
+  ;;
+  M)
+    sql="/usr/bin/mysql -NB -h$baculaDbAddr -P$baculaDbPort -u$baculaDbUser -p$baculaDbPass -D$baculaDbName -e"
+    timestampdiff="timestampdiff(second, StartTime, EndTime)"
+    speed="round(JobBytes / ${timestampdiff} / 1024, 2)"
+    compression="round(1 - JobBytes / ReadBytes, 2)"
+  ;;
   *) exit 7 ;;
 esac
+echo "[$baculaJobId] SQL Type: $baculaDbSgdb" | ${LOG} > /dev/null
 
 # Get Job type from database, then if it is a backup job, proceed, if not, exit
 baculaJobType=$($sql "select Type from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Type: ${baculaJobType}" | ${LOG} > /dev/null
 if [ "$baculaJobType" != "B" ] ; then exit 9 ; fi
 
 # Get Job level from database and classify it as Full, Differential, or Incremental
@@ -29,6 +48,7 @@ case $baculaJobLevel in
   'I') level='incr' ;;
   *)   exit 11 ;;
 esac
+echo "[$baculaJobId] Job Level: ${baculaJobLevel} => ${level}" | ${LOG} > /dev/null
 
 # Get Job exit status from database and classify it as OK, OK with warnings, or Fail
 baculaJobStatus=$($sql "select JobStatus from Job where JobId=$baculaJobId;" 2>/dev/null)
@@ -38,42 +58,51 @@ case $baculaJobStatus in
   "W") status=1 ;;
   *)   status=2 ;;
 esac
+echo "[$baculaJobId] Job Status: ${baculaJobStatus} => ${status}" | ${LOG} > /dev/null
 
 # Get client's name from database
 baculaClientName=$($sql "select Client.Name from Client,Job where Job.ClientId=Client.ClientId and Job.JobId=$baculaJobId;" 2>/dev/null)
 if [ -z $baculaClientName ] ; then exit 15 ; fi
+echo "[$baculaJobId] Client Name: ${baculaClientName}" | ${LOG} > /dev/null
 
 # Initialize return as zero
 return=0
 
 # Send Job exit status to Zabbix server
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+1)) ; fi
 
 # Get from database the number of bytes transferred by the Job and send it to Zabbix server
 baculaJobBytes=$($sql "select JobBytes from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
+echo "[$baculaJobId] Job Bytes: ${baculaJobBytes}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+2)) ; fi
 
 # Get from database the number of files transferred by the Job and send it to Zabbix server
 baculaJobFiles=$($sql "select JobFiles from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
+echo "[$baculaJobId] Job Files: ${baculaJobFiles}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+4)) ; fi
 
 # Get from database the time spent by the Job and send it to Zabbix server
-baculaJobTime=$($sql "select timestampdiff(second,StartTime,EndTime) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
+baculaJobTime=$($sql "select ${timestampdiff} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Time: ${baculaJobTime}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+8)) ; fi
 
 # Get Job speed from database and send it to Zabbix server
-baculaJobSpeed=$($sql "select round(JobBytes/timestampdiff(second,StartTime,EndTime)/1024,2) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
+baculaJobSpeed=$($sql "select ${speed} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Speed: ${baculaJobSpeed}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+16)) ; fi
 
 # Get Job compression rate from database and send it to Zabbix server
-baculaJobCompr=$($sql "select round(1-JobBytes/ReadBytes,2) from Job where JobId=$baculaJobId;" 2>/dev/null)
-$zabbixSender -z $zabbixSrvAddr -p $zabbixSrvPort -s $baculaClientName -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
+baculaJobCompr=$($sql "select ${compression} from Job where JobId=$baculaJobId;" 2>/dev/null)
+echo "[$baculaJobId] Job Compression: ${baculaJobCompr}" | ${LOG} > /dev/null
+$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+32)) ; fi
+
+echo "[$baculaJobId] END@ $(date +"%F %T") RETURN: ${return}" | ${LOG} > /dev/null
 
 # Exit with return status
 exit $return

--- a/bacula-zabbix.bash
+++ b/bacula-zabbix.bash
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 # Import configuration file
-source /etc/bacula/bacula-zabbix.conf
+# older path
+# source /etc/bacula/bacula-zabbix.conf
+# new path
+source /opt/bacula/etc/bacula-zabbix.conf
+
 # start tee logging
 LOG="tee -a ${scriptLogFile}"
 
@@ -69,37 +73,37 @@ echo "[$baculaJobId] Client Name: ${baculaClientName}" | ${LOG} > /dev/null
 return=0
 
 # Send Job exit status to Zabbix server
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.status" -o $status >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+1)) ; fi
 
 # Get from database the number of bytes transferred by the Job and send it to Zabbix server
 baculaJobBytes=$($sql "select JobBytes from Job where JobId=$baculaJobId;" 2>/dev/null)
 echo "[$baculaJobId] Job Bytes: ${baculaJobBytes}" | ${LOG} > /dev/null
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.bytes" -o $baculaJobBytes >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+2)) ; fi
 
 # Get from database the number of files transferred by the Job and send it to Zabbix server
 baculaJobFiles=$($sql "select JobFiles from Job where JobId=$baculaJobId;" 2>/dev/null)
 echo "[$baculaJobId] Job Files: ${baculaJobFiles}" | ${LOG} > /dev/null
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.files" -o $baculaJobFiles >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+4)) ; fi
 
 # Get from database the time spent by the Job and send it to Zabbix server
 baculaJobTime=$($sql "select ${timestampdiff} from Job where JobId=$baculaJobId;" 2>/dev/null)
 echo "[$baculaJobId] Job Time: ${baculaJobTime}" | ${LOG} > /dev/null
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.time" -o $baculaJobTime >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+8)) ; fi
 
 # Get Job speed from database and send it to Zabbix server
 baculaJobSpeed=$($sql "select ${speed} from Job where JobId=$baculaJobId;" 2>/dev/null)
 echo "[$baculaJobId] Job Speed: ${baculaJobSpeed}" | ${LOG} > /dev/null
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.speed" -o $baculaJobSpeed >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+16)) ; fi
 
 # Get Job compression rate from database and send it to Zabbix server
 baculaJobCompr=$($sql "select ${compression} from Job where JobId=$baculaJobId;" 2>/dev/null)
 echo "[$baculaJobId] Job Compression: ${baculaJobCompr}" | ${LOG} > /dev/null
-$zabbixSender -c $zabbixAgentConfig -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
+$zabbixSender -z $zabbixServer -c $zabbixAgentConfig -k "bacula.$level.job.compr" -o $baculaJobCompr >/dev/null 2>&1
 if [ $? -ne 0 ] ; then return=$(($return+32)) ; fi
 
 echo "[$baculaJobId] END@ $(date +"%F %T") RETURN: ${return}" | ${LOG} > /dev/null

--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -25,8 +25,8 @@ baculaDbPass='linux01'
 # Config for the zabbix agent
 zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
-# Config for the zabbix agent
-zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
+# Zabbix sender executable path
+zabbixSender='/usr/bin/zabbix_sender'
 
 
 ### SCRIPT LOG FILE ###

--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -7,7 +7,7 @@ baculaDbSgdb='M'
 # IP address or FQDN of database server
 baculaDbAddr='127.0.0.1'
 
-# TCP port of database server
+# TCP port of database server (3306 of MySQL, 5432 for PostgreSQL)
 baculaDbPort='3306'
 
 # Name of the database used by Bacula
@@ -22,11 +22,14 @@ baculaDbPass='linux01'
 
 ### ZABBIX CONFIG ###
 
-# IP address or FQDN of Zabbix server
-zabbixSrvAddr='192.168.37.200'
+# Config for the zabbix agent
+zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
-# TCP port of Zabbix server
-zabbixSrvPort='10051'
+# Config for the zabbix agent
+zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
-# Path to zabbix_sender command
-zabbixSender='/usr/bin/zabbix_sender'
+
+### SCRIPT LOG FILE ###
+
+# debug log file (must be writeable by bacula user)
+scriptLogFile="/var/log/bacula/bacula-zabbix.log";

--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -33,8 +33,8 @@ baculaDbPass='linux01'
 ### ZABBIX CONFIG ###
 
 # Config for the zabbix agent
-# Zabbix Server                                                                                                        35,1          75%
-zabbixServer='10.2.38.102'  
+# Zabbix Server IP
+zabbixServer='192.168.0.1'
 
 zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 

--- a/bacula-zabbix.conf
+++ b/bacula-zabbix.conf
@@ -2,13 +2,23 @@
 
 # Use 'M' for MySQL
 # Use 'P' for PostgreSQL
-baculaDbSgdb='M'
+baculaDbSgdb='P'
+
+# Escolher o SGDB e definir a porta automaticamente, se não for definida manualmente
+if [ "$baculaDbSgdb" == "M" ]; then
+  baculaDbPort=${baculaDbPort:-3306}  # Porta padrão para MySQL
+elif [ "$baculaDbSgdb" == "P" ]; then
+  baculaDbPort=${baculaDbPort:-5432}  # Porta padrão para PostgreSQL
+else
+  echo "Erro: O SGDB deve ser 'M' para MySQL ou 'P' para PostgreSQL."
+  exit 1
+fi
 
 # IP address or FQDN of database server
 baculaDbAddr='127.0.0.1'
 
-# TCP port of database server (3306 of MySQL, 5432 for PostgreSQL)
-baculaDbPort='3306'
+# Can Uncomment below and set manually TCP port of database server (3306 of MySQL, 5432 for PostgreSQL)
+# baculaDbPort='5432'
 
 # Name of the database used by Bacula
 baculaDbName='bacula'
@@ -23,6 +33,9 @@ baculaDbPass='linux01'
 ### ZABBIX CONFIG ###
 
 # Config for the zabbix agent
+# Zabbix Server                                                                                                        35,1          75%
+zabbixServer='10.2.38.102'  
+
 zabbixAgentConfig='/etc/zabbix/zabbix_agentd.conf'
 
 # Zabbix sender executable path


### PR DESCRIPTION
- fixed typo: bacula-sender.sh to bacula-sender.bash
- change default path `/etc/bacula` to `/opt/bacula/etc` (new path)
- added $zabbixServer so you can choose which snmptraps server to send
- some README file fixes

tested on: zabbix 6.4 and bacula 11.0.6